### PR TITLE
use rm -f and remove unnecessary lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BINDIR = bin
 
 # Compiler rules
 CC=gcc
-CFLAGS=-I$(INCDIR) -lm -Wall -O3
+CFLAGS=-I$(INCDIR) -Wall -Wextra -O3
 
 # Linker flags and libs
 LDFLAGS=-lm
@@ -30,14 +30,13 @@ $(BINDIR)/$(TARGET): $(OBJECTS)
 # the headers to change very often. It would be cleaner to build
 # a list of header files that each source file depends on, especially
 # since this will be a relatively small project.
-$(OBJECTS): $(OBJDIR)/%.o : $(SRCDIR)/%.c $(INCLUDES)
+$(OBJDIR)/%.o: $(SRCDIR)/%.c $(INCLUDES)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 .PHONY: clean clean_all
 
 clean:
-	rm $(BINDIR)/$(TARGET) 
+	rm -f $(BINDIR)/$(TARGET)
 
-cleanall:
-	rm $(BINDIR)/$(TARGET) 
-	rm $(OBJECTS)
+cleanall: clean
+	rm -f $(OBJECTS)


### PR DESCRIPTION
1. We don't need `-lm` when compiling, just when linking.
2. We don't need to have `$(OBJECTS)` as an explicit target, and it would be difficult to add additional files not in `$(OBJDIR)` this way, if we ever want to do that.
3. As discussed [here](https://github.com/sc3260s16/announce/issues/7#issuecomment-183540528).

With regards to your comment above the `$(OBJDIR)/%.o` target, `gcc -M` can generate the required includes for each source file in a Makefile-ready format, but invoking gcc to perform `-M` is often about as fast as just recompiling the source file in a small project like this, so it's not super necessary.
